### PR TITLE
Project dropdown shows project names from table.

### DIFF
--- a/app.py
+++ b/app.py
@@ -320,8 +320,10 @@ def push_to_md():
     logging.info("upsert records into motherduck")
 
 
-def motherduck_list_projects():
-    return con.sql("SELECT DISTINCT name FROM project").df()
+def motherduck_list_projects(author_id):
+    return con.sql(f"""
+        SELECT DISTINCT name FROM project WHERE authorId = '{author_id}'
+    """).df()
 
 
 with gr.Blocks() as demo:
@@ -371,8 +373,11 @@ with gr.Blocks() as demo:
     view_btn.click(view_all, outputs=results_df)
     save_btn.click(push_to_md)
 
-    def update_project_dropdown_list(x):
-        projects = motherduck_list_projects()
+    def update_project_dropdown_list(url_params):
+        print('url_params', url_params['username'])
+
+        projects = motherduck_list_projects(author_id = url_params['username'])
+        print('projects', projects)
         # to-do: filter projects based on user
         return gr.Dropdown.update(choices=projects["name"].tolist())
 

--- a/app.py
+++ b/app.py
@@ -11,6 +11,9 @@ import plotly.graph_objects as go
 import yaml
 from google.oauth2 import service_account
 
+
+from utils.js import get_window_url_params
+
 # Logging
 logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
 
@@ -317,6 +320,10 @@ def push_to_md():
     logging.info("upsert records into motherduck")
 
 
+def motherduck_list_projects():
+    return con.sql("SELECT DISTINCT name FROM project").df()
+
+
 with gr.Blocks() as demo:
     # Environment setup
     authenticate_gee(GEE_SERVICE_ACCOUNT, GEE_SERVICE_ACCOUNT_CREDENTIALS_FILE)
@@ -341,7 +348,8 @@ with gr.Blocks() as demo:
         with gr.Row():
             start_year = gr.Number(value=2017, label="Start Year", precision=0)
             end_year = gr.Number(value=2022, label="End Year", precision=0)
-            project_name = gr.Textbox(label="Project Name")
+            # project_name = gr.Textbox(label="Project Name")
+            project_name = gr.Dropdown([], label="Project", value="Select project")
         # boroughs = gr.CheckboxGroup(choices=["Queens", "Brooklyn", "Manhattan", "Bronx", "Staten Island"], value=["Queens", "Brooklyn"], label="Select Methodology:")
         # btn = gr.Button(value="Update Filter")
         with gr.Row():
@@ -362,5 +370,28 @@ with gr.Blocks() as demo:
     )
     view_btn.click(view_all, outputs=results_df)
     save_btn.click(push_to_md)
+
+    def update_project_dropdown_list(x):
+        projects = motherduck_list_projects()
+        # to-do: filter projects based on user
+        return gr.Dropdown.update(choices=projects["name"].tolist())
+
+    # Get url params
+    url_params = gr.JSON({"username": "default"}, visible=False, label="URL Params")
+
+    # Gradio has a bug
+    # For dropdown to update by demo.load, dropdown value must be called downstream
+    b1 = gr.Button("Hidden button that fixes bug.", visible=False)
+    b1.click(lambda x: x, inputs=project_name, outputs=[])
+
+    # Update project dropdown list on page load
+    demo.load(
+        fn=update_project_dropdown_list,
+        inputs=[url_params],
+        outputs=[project_name],
+        _js=get_window_url_params,
+        queue=False,
+    )
+
 
 demo.launch()

--- a/app.py
+++ b/app.py
@@ -321,9 +321,11 @@ def push_to_md():
 
 
 def motherduck_list_projects(author_id):
-    return con.sql(f"""
+    return con.sql(
+        f"""
         SELECT DISTINCT name FROM project WHERE authorId = '{author_id}'
-    """).df()
+    """
+    ).df()
 
 
 with gr.Blocks() as demo:
@@ -374,10 +376,8 @@ with gr.Blocks() as demo:
     save_btn.click(push_to_md)
 
     def update_project_dropdown_list(url_params):
-        print('url_params', url_params['username'])
-
-        projects = motherduck_list_projects(author_id = url_params['username'])
-        print('projects', projects)
+        username = url_params.get("username", "default")
+        projects = motherduck_list_projects(author_id=username)
         # to-do: filter projects based on user
         return gr.Dropdown.update(choices=projects["name"].tolist())
 

--- a/utils/js.py
+++ b/utils/js.py
@@ -1,0 +1,8 @@
+get_window_url_params = """
+    function() {
+        const params = new URLSearchParams(window.location.search);
+        const url_params = Object.fromEntries(params);
+        console.log('url_params', url_params)
+        return url_params;
+        }
+    """


### PR DESCRIPTION
# Description

This PR replaces the project text field with a dropdown. On render, the dropdown options are populated from the list of project names, queried from duckdb `project` table. 

This PR also enables the gradio app to read URL query parameters into a dict. This will enable the Typescript app to pass the username as a query parameter, then filter projects for that username. For example:

```bash
http://127.0.0.1:7861/?username=MY_USERNAME
```

# Screenshots

<img width="1278" alt="image" src="https://github.com/openbiodiversity/calculator/assets/27398253/ef154835-aaab-40c4-9c24-c7dda6525a59">
